### PR TITLE
fixes error in 'current_error.jpg'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ It uses poetry. After cloning,
 poetry install
 ```
 
+If you do not have `python 3.8` as the default python or a virtual environment based on python 3.8, you might run into some python version issues. In such cases, follow the below steps -
+```bash
+# install virtualenv and pyenv
+brew install pyenv pyenv-virtualenv
+# install python3.8.0
+pyenv install 3.8.0
+# create a virtualenv with python3.8.0
+pyenv virtualenv 3.8.0 dl_env
+# activate the environment
+source ~/.pyenv/versions/dl_env/bin/activate
+# install dependencies
+poetry install
+```
+
 To train the model,
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ configs_local = {
     "max_len": 64,
     "train_batch_size": 32,
     "eval_batch_size": 8,
-    "epochs": 1,
+    "epochs": 3,
     "lr": 3e-5,
     "datapath": "data/cola_public_1.1/cola_public/raw/",
 }

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ configs_local = {
     "max_len": 64,
     "train_batch_size": 32,
     "eval_batch_size": 8,
-    "epochs": 3,
+    "epochs": 1,
     "lr": 3e-5,
     "datapath": "data/cola_public_1.1/cola_public/raw/",
 }

--- a/main.py
+++ b/main.py
@@ -6,3 +6,4 @@ from transformers import AdamWeightDecay, WarmUp
 
 exp = ColaData(configs_local.datapath)
 exp.train(configs_local, BertModel(), bce, AdamWeightDecay(learning_rate=configs_local.lr))
+exp.create_submission()

--- a/tfbert/cola_data.py
+++ b/tfbert/cola_data.py
@@ -163,10 +163,11 @@ class ColaData:
     def create_submission(self):
         # To be done
         self.test_dataset = BertDataset.create(
-            self.testdf["Sentence"].values, [[0, 1]] * len(df_test), EVAL_BATCH_SIZE  # creating fake labels
+            self.testdf["Sentence"].values, [[0, 1]] * len(self.testdf), config.eval_batch_size  # creating fake labels
         )
-        preds = self.predict(test_dataset)
+        preds = self.predict(self.test_dataset)
         preds = [item for sublist in preds for item in sublist]
-        df_test["Label"] = preds
-        print(f"\n\nTest Data: \ndf_test['Label'].value_counts()")
-        df_test[["Id", "Label"]].to_csv("sample_submission.csv", index=False)
+        self.testdf["Label"] = preds
+        print(f"\n\nTest Data: \nself.testdf['Label'].value_counts()")
+        self.testdf[["Id", "Label"]].to_csv("sample_submission.csv", index=False)
+

--- a/tfbert/cola_data.py
+++ b/tfbert/cola_data.py
@@ -161,13 +161,13 @@ class ColaData:
         return preds
 
     def create_submission(self):
-        # To be done
         self.test_dataset = BertDataset.create(
-            self.testdf["Sentence"].values, [[0, 1]] * len(self.testdf), config.eval_batch_size  # creating fake labels
+            self.testdf["Sentence"].values, [[0, 1]] * len(self.testdf), # creating fake labels 
+            self.config.max_len, self.config.eval_batch_size  
         )
         preds = self.predict(self.test_dataset)
         preds = [item for sublist in preds for item in sublist]
         self.testdf["Label"] = preds
-        print(f"\n\nTest Data: \nself.testdf['Label'].value_counts()")
+        print(f"\n\nTest Data: \n{self.testdf['Label'].value_counts()}")
         self.testdf[["Id", "Label"]].to_csv("sample_submission.csv", index=False)
 


### PR DESCRIPTION
## Resolving Error
The `args` argument in `tf.data.Dataset.from_generator` accepts only a tuple of Tensors. Since, you were trying to pass an object of class `transformers.tokenization_bert.BertTokenizerFast`, it was trying to convert the object to a tensor and failed. Notice the call to `convert_to_tensor` in the traceback. [`tf.data.Dataset.from_generator` - TensorFlow Doc](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#from_generator)

I have modified the code as in the Kaggle kernel & it works. The only downside is that the vocabulary path to `tokenizer` is currently hardcoded.

## Predict Function
I have added a `predict` function inside `ColaData` class that takes in test dataset of type `tf.data.Dataset` & returns predictions as a list. 

I have tested out both of them in this [colab notebook](https://colab.research.google.com/drive/1I7sefgBiEiqFv8Gd-boMg0tBJlaMhcpL?usp=sharing)